### PR TITLE
allow pass in compare-from push and pr options

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -7,6 +7,12 @@ inputs:
   github_token:
     description: "A GitHub token that can append comments to a PR"
     required: true
+  compare_from_push:
+    description: "Set the ref to compare from in push events"
+    required: false
+  compare_from_pr:
+    description: "Set the ref to compare from in pull request events"
+    required: false
   standards_fail:
     description: "Fail the action if a standard fails"
     required: false

--- a/src/__tests__/action.test.ts
+++ b/src/__tests__/action.test.ts
@@ -4,38 +4,38 @@ import * as exec from "@actions/exec";
 jest.mock("@actions/exec");
 
 test("invalid input", async () => {
-  const exitCode = await runAction(
-    "optic-token",
-    "github-token",
-    "",
-    "true",
-    "",
-    "",
-    undefined,
-    "owner",
-    "repo",
-    "abc123",
-    ""
-  );
+  const exitCode = await runAction("optic-token", "github-token", {
+    additionalArgs: "",
+    standardsFail: "true",
+    eventName: "",
+    headRef: "",
+    baseRef: undefined,
+    owner: "owner",
+    repo: "repo",
+    sha: "abc123",
+    refName: "",
+    compareFromPush: undefined,
+    compareFromPr: undefined,
+  });
   expect(exitCode).toBe(1);
 });
 
 test("failed install", async () => {
   const assertFailedInstall = mockFailedInstall();
 
-  const exitCode = await runAction(
-    "optic-token",
-    "github-token",
-    "",
-    "true",
-    "push",
-    "refs/heads/main",
-    undefined,
-    "owner",
-    "repo",
-    "abc123",
-    "main"
-  );
+  const exitCode = await runAction("optic-token", "github-token", {
+    additionalArgs: "",
+    standardsFail: "true",
+    eventName: "push",
+    headRef: "refs/heads/main",
+    baseRef: undefined,
+    owner: "owner",
+    repo: "repo",
+    sha: "abc123",
+    refName: "main",
+    compareFromPush: undefined,
+    compareFromPr: undefined,
+  });
   expect(exitCode).toBe(1);
   assertFailedInstall();
 });
@@ -46,19 +46,19 @@ test("pull_request event", async () => {
   const assertDiffAll = mockDiffAll("token", "origin/main");
   const assertGitHubComment = mockGitHubComment();
 
-  const exitCode = await runAction(
-    "optic-token",
-    "github-token",
-    "",
-    "true",
-    "pull_request",
-    "refs/pulls/1/merge",
-    "main",
-    "owner",
-    "repo",
-    "abc123",
-    "main"
-  );
+  const exitCode = await runAction("optic-token", "github-token", {
+    additionalArgs: "",
+    standardsFail: "true",
+    eventName: "pull_request",
+    headRef: "refs/pulls/1/merge",
+    baseRef: "main",
+    owner: "owner",
+    repo: "repo",
+    sha: "abc123",
+    refName: "main",
+    compareFromPush: undefined,
+    compareFromPr: undefined,
+  });
   expect(exitCode).toBe(0);
   assertInstall();
   assertEnsureRef();
@@ -71,19 +71,19 @@ test("push event", async () => {
   const assertDeepen = mockDeepen();
   const assertDiffAll = mockDiffAll("optic-token", "HEAD~1");
 
-  const exitCode = await runAction(
-    "optic-token",
-    "github-token",
-    "",
-    "true",
-    "push",
-    "refs/heads/main",
-    undefined,
-    "owner",
-    "repo",
-    "abc123",
-    "main"
-  );
+  const exitCode = await runAction("optic-token", "github-token", {
+    additionalArgs: "",
+    standardsFail: "true",
+    eventName: "push",
+    headRef: "refs/heads/main",
+    baseRef: "main",
+    owner: "owner",
+    repo: "repo",
+    sha: "abc123",
+    refName: "main",
+    compareFromPush: undefined,
+    compareFromPr: undefined,
+  });
   expect(exitCode).toBe(0);
   assertInstall();
   assertDeepen();
@@ -97,19 +97,19 @@ test("push event with additional-args", async () => {
     "--fail-on-untracked-openapi",
   ]);
 
-  const exitCode = await runAction(
-    "optic-token",
-    "github-token",
-    "--fail-on-untracked-openapi",
-    "true",
-    "push",
-    "refs/heads/main",
-    undefined,
-    "owner",
-    "repo",
-    "abc123",
-    "main"
-  );
+  const exitCode = await runAction("optic-token", "github-token", {
+    additionalArgs: "--fail-on-untracked-openapi",
+    standardsFail: "true",
+    eventName: "push",
+    headRef: "refs/heads/main",
+    baseRef: undefined,
+    owner: "owner",
+    repo: "repo",
+    sha: "abc123",
+    refName: "main",
+    compareFromPush: undefined,
+    compareFromPr: undefined,
+  });
   expect(exitCode).toBe(0);
   assertInstall();
   assertDeepen();
@@ -121,19 +121,19 @@ test("push event with standards failure and standards_fail set to true", async (
   const assertDeepen = mockDeepen();
   const assertDiffAll = mockDiffAll("optic-token", "HEAD~1", true);
 
-  const exitCode = await runAction(
-    "optic-token",
-    "github-token",
-    "",
-    "true",
-    "push",
-    "refs/heads/main",
-    undefined,
-    "owner",
-    "repo",
-    "abc123",
-    "main"
-  );
+  const exitCode = await runAction("optic-token", "github-token", {
+    additionalArgs: "",
+    standardsFail: "true",
+    eventName: "push",
+    headRef: "refs/heads/main",
+    baseRef: undefined,
+    owner: "owner",
+    repo: "repo",
+    sha: "abc123",
+    refName: "main",
+    compareFromPush: undefined,
+    compareFromPr: undefined,
+  });
   expect(exitCode).toBe(1);
   assertInstall();
   assertDeepen();
@@ -145,20 +145,66 @@ test("push event with standards failure but standards_fail set to false", async 
   const assertDeepen = mockDeepen();
   const assertDiffAll = mockDiffAll("optic-token", "HEAD~1", true);
 
-  const exitCode = await runAction(
-    "optic-token",
-    "github-token",
-    "",
-    "false",
-    "push",
-    "refs/heads/main",
-    undefined,
-    "owner",
-    "repo",
-    "abc123",
-    "main"
-  );
+  const exitCode = await runAction("optic-token", "github-token", {
+    additionalArgs: "",
+    standardsFail: "false",
+    eventName: "push",
+    headRef: "refs/heads/main",
+    baseRef: undefined,
+    owner: "owner",
+    repo: "repo",
+    sha: "abc123",
+    refName: "main",
+    compareFromPush: undefined,
+    compareFromPr: undefined,
+  });
   expect(exitCode).toBe(0);
+  assertInstall();
+  assertDeepen();
+  assertDiffAll();
+});
+
+test("push event with compare-from-push override with cloud", async () => {
+  const assertInstall = mockInstall();
+  const assertDiffAll = mockDiffAll("optic-token", "cloud:tag", true);
+
+  const exitCode = await runAction("optic-token", "github-token", {
+    additionalArgs: "",
+    standardsFail: "true",
+    eventName: "push",
+    headRef: "refs/heads/main",
+    baseRef: undefined,
+    owner: "owner",
+    repo: "repo",
+    sha: "abc123",
+    refName: "main",
+    compareFromPush: "cloud:tag",
+    compareFromPr: undefined,
+  });
+  expect(exitCode).toBe(1);
+  assertInstall();
+  assertDiffAll();
+});
+
+test("pull request event with compare-from-push override with HEAD", async () => {
+  const assertInstall = mockInstall();
+  const assertDeepen = mockDeepen();
+  const assertDiffAll = mockDiffAll("optic-token", "HEAD~1", true);
+
+  const exitCode = await runAction("optic-token", "github-token", {
+    additionalArgs: "",
+    standardsFail: "true",
+    eventName: "pull_request",
+    headRef: "refs/pulls/1/merge",
+    baseRef: "main",
+    owner: "owner",
+    repo: "repo",
+    sha: "abc123",
+    refName: "main",
+    compareFromPush: undefined,
+    compareFromPr: "HEAD~1",
+  });
+  expect(exitCode).toBe(1);
   assertInstall();
   assertDeepen();
   assertDiffAll();

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,8 @@ const opticToken = core.getInput("optic_token");
 const githubToken = core.getInput("github_token");
 const standardsFail = core.getInput("standards_fail");
 const additionalArgs = core.getInput("additional_args");
+const compareFromPush = core.getInput("compare_from_push");
+const compareFromPr = core.getInput("compare_from_pr");
 
 const eventName = process.env.GITHUB_EVENT_NAME;
 const headRef = process.env.GITHUB_REF;
@@ -14,9 +16,7 @@ const owner = process.env.GITHUB_REPOSITORY_OWNER;
 const repo = process.env.GITHUB_REPOSITORY?.split("/")[1];
 const sha = process.env.GITHUB_SHA;
 
-runAction(
-  opticToken,
-  githubToken,
+runAction(opticToken, githubToken, {
   additionalArgs,
   standardsFail,
   eventName,
@@ -25,8 +25,10 @@ runAction(
   owner,
   repo,
   sha,
-  refName
-)
+  refName,
+  compareFromPush,
+  compareFromPr,
+})
   .then((exitCode) => {
     return process.exit(exitCode);
   })


### PR DESCRIPTION
Allow passing in `compare-from` for push and pr events

Will be useful when we merge the `--generated` PR https://github.com/opticdev/optic/pull/1883